### PR TITLE
chore: add entrypoint.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM ruby:3.4.5
 
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock .
 RUN bundle install
 COPY . .
+
+ENTRYPOINT ["./entrypoint.sh"]
 
 CMD ["bin/rails", "s", "-b", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   web:
     build: .
-    command: sh -c "bin/rails db:prepare && bin/rails server --binding 0.0.0.0"
     depends_on:
       db:
         condition: service_healthy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+rm -f tmp/pids/server.pid
+
+bin/rails db:prepare 2>/dev/null || true
+
+exec "$@"


### PR DESCRIPTION
This PR adds the entrypoint.sh script to allow the application to be prepared before it starts.