### PR TITLE
feat: add imports index action

### DIFF
--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -15,8 +15,8 @@ class Api::V1::ProductsController < ApplicationController
 
     products = ActiveRecord::Base.connected_to(role: :reading) do
       Product.order(:id)
-             .page(params[:page])
-             .per(params[:per_page])
+             .page(page)
+             .per(per_page)
              .pluck(Arel.sql('id AS product_id'), Arel.sql('price_cents / 100.0 AS value'))
              .collect { |product_id, value| { product_id:, value: } }
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
       missing_file: File is required
       invalid_file: Invalid file
       invalid_file_type: Invalid file type
+      invalid_page: Invalid page
+      invalid_per_page: Invalid per_page
   products:
     errors:
       invalid_page: Invalid page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api do
     namespace :v1 do
-      resources :imports, only: %i[create]
+      resources :imports, only: %i[index create]
       resources :products, only: %i[index]
     end
   end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Products', type: :request do
-  before { create_list(:product, 50) }
-
   describe 'GET /index' do
+    before { create_list(:product, 50) }
+
     it 'returns a list of products' do
       get '/api/v1/products'
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -64,6 +64,42 @@ paths:
                 properties:
                   error:
                     type: string
+    get:
+      tags:
+        - imports
+      summary: List imports
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    import_id:
+                      type: integer
+                    status:
+                      type: string
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
   /products:
     get:
       tags:
@@ -84,13 +120,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  product_id:
-                    type: integer
-                  value:
-                    type: number
-                    format: double
+                type: array
+                items:
+                  type: object
+                  properties:
+                    product_id:
+                      type: integer
+                    value:
+                      type: number
+                      format: double
         '400':
           description: Bad Request
           content:


### PR DESCRIPTION
## Problem

It's required to have an endpoint for listing the imports.

## Solution

This PR adds the Imports Controller index action to list the imports.

## :stethoscope: Testing

**Setup**

```sh
docker compose build
```

```sh
docker compose up -d
```

Import the orders files following the steps of PR #5

**:test_tube: Scenario 1:** List the imports using the imports resource

<img width="1472" height="957" alt="image" src="https://github.com/user-attachments/assets/3da126df-8c7c-4e8d-bfe9-b9b8086b5c9d" />
