### PR TITLE
feat: add orders controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  NewCops: enable
+  Exclude:
+    - 'db/schema.rb'
+    - 'vendor/**/*'
+    - 'node_modules/**/*'
+    - 'bin/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Style/Documentation:
+  Enabled: false

--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -1,48 +1,52 @@
 # frozen_string_literal: true
 
-class Api::V1::ImportsController < ApplicationController
-  def index
-    page = params[:page]
-    per_page = params[:per_page]
+module Api
+  module V1
+    class ImportsController < ApplicationController
+      def index
+        page = params[:page]
+        per_page = params[:per_page]
 
-    if page.present? && page.to_i <= 0
-      return render json: { error: I18n.t('imports.errors.invalid_page') }, status: :bad_request
+        if page.present? && page.to_i <= 0
+          return render json: { error: I18n.t('imports.errors.invalid_page') }, status: :bad_request
+        end
+
+        if per_page.present? && per_page.to_i <= 0
+          return render json: { error: I18n.t('imports.errors.invalid_per_page') }, status: :bad_request
+        end
+
+        imports = ActiveRecord::Base.connected_to(role: :reading) do
+          Import
+            .order(:created_at)
+            .page(page)
+            .per(params[:per_page])
+            .pluck(Arel.sql('id AS import_id'), :status)
+            .collect { |import_id, status| { import_id:, status: } }
+        end
+
+        render json: imports
+      end
+
+      def create
+        unless params[:file].present?
+          return render json: { error: I18n.t('imports.errors.missing_file') }, status: :bad_request
+        end
+
+        unless params[:file].is_a?(ActionDispatch::Http::UploadedFile)
+          return render json: { error: I18n.t('imports.errors.invalid_file') }, status: :unprocessable_content
+        end
+
+        unless params[:file].content_type == 'text/plain'
+          return render json: { error: I18n.t('imports.errors.invalid_file_type') }, status: :unsupported_media_type
+        end
+
+        import = Import.create!(status: :pending)
+        import.file.attach(params[:file])
+
+        ImportJob.perform_async(import.id)
+
+        render json: { import_id: import.id }, status: :created
+      end
     end
-
-    if per_page.present? && per_page.to_i <= 0
-      return render json: { error: I18n.t('imports.errors.invalid_per_page') }, status: :bad_request
-    end
-
-    imports = ActiveRecord::Base.connected_to(role: :reading) do
-      Import
-        .order(:created_at)
-        .page(page)
-        .per(params[:per_page])
-        .pluck(Arel.sql('id AS import_id'), :status)
-        .collect { |import_id, status| { import_id:, status: } }
-    end
-
-    render json: imports
-  end
-
-  def create
-    unless params[:file].present?
-      return render json: { error: I18n.t('imports.errors.missing_file') }, status: :bad_request
-    end
-
-    unless params[:file].is_a?(ActionDispatch::Http::UploadedFile)
-      return render json: { error: I18n.t('imports.errors.invalid_file') }, status: :unprocessable_content
-    end
-
-    unless params[:file].content_type == 'text/plain'
-      return render json: { error: I18n.t('imports.errors.invalid_file_type') }, status: :unsupported_media_type
-    end
-
-    import = Import.create!(status: :pending)
-    import.file.attach(params[:file])
-
-    ImportJob.perform_async(import.id)
-
-    render json: { import_id: import.id }, status: :created
   end
 end

--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -13,12 +13,14 @@ class Api::V1::ImportsController < ApplicationController
       return render json: { error: I18n.t('imports.errors.invalid_per_page') }, status: :bad_request
     end
 
-    imports = Import
-              .order(:created_at)
-              .page(page)
-              .per(params[:per_page])
-              .pluck(Arel.sql('id AS import_id'), :status)
-              .collect { |import_id, status| { import_id:, status: } }
+    imports = ActiveRecord::Base.connected_to(role: :reading) do
+      Import
+        .order(:created_at)
+        .page(page)
+        .per(params[:per_page])
+        .pluck(Arel.sql('id AS import_id'), :status)
+        .collect { |import_id, status| { import_id:, status: } }
+    end
 
     render json: imports
   end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -15,19 +15,21 @@ module Api
           return render json: { error: I18n.t('orders.errors.invalid_per_page') }, status: :bad_request
         end
 
-        orders = Order
-                 .select(
-                   'orders.id AS order_id',
-                   'orders.date AS date',
-                   "to_char(SUM(order_items.price_cents) / 100.0, 'FM999999999.00') AS total",
-                   "json_agg(json_build_object('product_id', order_items.product_id, 'value', to_char(order_items.price_cents / 100.0, 'FM999999999.00'))) AS products"
-                 )
-                 .joins(:order_items)
-                 .group('orders.id', 'orders.date')
-                 .order(:id)
-                 .page(params[:page])
-                 .per(params[:per_page])
-                 .collect { |o| { order_id: o.order_id, date: o.date, total: o.total, products: o.products } }
+        orders = ActiveRecord::Base.connected_to(role: :reading) do
+          Order
+            .select(
+              'orders.id AS order_id',
+              'orders.date AS date',
+              "to_char(SUM(order_items.price_cents) / 100.0, 'FM999999999.00') AS total",
+              "json_agg(json_build_object('product_id', order_items.product_id, 'value', to_char(order_items.price_cents / 100.0, 'FM999999999.00'))) AS products"
+            )
+            .joins(:order_items)
+            .group('orders.id', 'orders.date')
+            .order(:id)
+            .page(params[:page])
+            .per(params[:per_page])
+            .collect { |o| { order_id: o.order_id, date: o.date, total: o.total, products: o.products } }
+        end
 
         render json: orders
       end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Api::V1::OrdersController < ApplicationController
+  def index
+    page = params[:page]
+    per_page = params[:per_page]
+
+    if page.present? && page.to_i <= 0
+      return render json: { error: I18n.t('orders.errors.invalid_page') }, status: :bad_request
+    end
+
+    if per_page.present? && per_page.to_i <= 0
+      return render json: { error: I18n.t('orders.errors.invalid_per_page') }, status: :bad_request
+    end
+
+    orders = Order
+             .select(
+               'orders.id AS order_id',
+               'orders.date AS date',
+               "to_char(SUM(order_items.price_cents) / 100.0, 'FM999999999.00') AS total",
+               "json_agg(json_build_object('product_id', order_items.product_id, 'value', to_char(order_items.price_cents / 100.0, 'FM999999999.00'))) AS products"
+             )
+             .joins(:order_items)
+             .group('orders.id', 'orders.date')
+             .order(:id)
+             .page(params[:page])
+             .per(params[:per_page])
+             .collect { |o| { order_id: o.order_id, date: o.date, total: o.total, products: o.products } }
+
+    render json: orders
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,32 +1,36 @@
 # frozen_string_literal: true
 
-class Api::V1::OrdersController < ApplicationController
-  def index
-    page = params[:page]
-    per_page = params[:per_page]
+module Api
+  module V1
+    class OrdersController < ApplicationController
+      def index
+        page = params[:page]
+        per_page = params[:per_page]
 
-    if page.present? && page.to_i <= 0
-      return render json: { error: I18n.t('orders.errors.invalid_page') }, status: :bad_request
+        if page.present? && page.to_i <= 0
+          return render json: { error: I18n.t('orders.errors.invalid_page') }, status: :bad_request
+        end
+
+        if per_page.present? && per_page.to_i <= 0
+          return render json: { error: I18n.t('orders.errors.invalid_per_page') }, status: :bad_request
+        end
+
+        orders = Order
+                 .select(
+                   'orders.id AS order_id',
+                   'orders.date AS date',
+                   "to_char(SUM(order_items.price_cents) / 100.0, 'FM999999999.00') AS total",
+                   "json_agg(json_build_object('product_id', order_items.product_id, 'value', to_char(order_items.price_cents / 100.0, 'FM999999999.00'))) AS products"
+                 )
+                 .joins(:order_items)
+                 .group('orders.id', 'orders.date')
+                 .order(:id)
+                 .page(params[:page])
+                 .per(params[:per_page])
+                 .collect { |o| { order_id: o.order_id, date: o.date, total: o.total, products: o.products } }
+
+        render json: orders
+      end
     end
-
-    if per_page.present? && per_page.to_i <= 0
-      return render json: { error: I18n.t('orders.errors.invalid_per_page') }, status: :bad_request
-    end
-
-    orders = Order
-             .select(
-               'orders.id AS order_id',
-               'orders.date AS date',
-               "to_char(SUM(order_items.price_cents) / 100.0, 'FM999999999.00') AS total",
-               "json_agg(json_build_object('product_id', order_items.product_id, 'value', to_char(order_items.price_cents / 100.0, 'FM999999999.00'))) AS products"
-             )
-             .joins(:order_items)
-             .group('orders.id', 'orders.date')
-             .order(:id)
-             .page(params[:page])
-             .per(params[:per_page])
-             .collect { |o| { order_id: o.order_id, date: o.date, total: o.total, products: o.products } }
-
-    render json: orders
   end
 end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,26 +1,30 @@
 # frozen_string_literal: true
 
-class Api::V1::ProductsController < ApplicationController
-  def index
-    page = params[:page]
-    per_page = params[:per_page]
+module Api
+  module V1
+    class ProductsController < ApplicationController
+      def index
+        page = params[:page]
+        per_page = params[:per_page]
 
-    if page.present? && page.to_i <= 0
-      return render json: { error: I18n.t('products.errors.invalid_page') }, status: :bad_request
+        if page.present? && page.to_i <= 0
+          return render json: { error: I18n.t('products.errors.invalid_page') }, status: :bad_request
+        end
+
+        if per_page.present? && per_page.to_i <= 0
+          return render json: { error: I18n.t('products.errors.invalid_per_page') }, status: :bad_request
+        end
+
+        products = ActiveRecord::Base.connected_to(role: :reading) do
+          Product.order(:id)
+                 .page(page)
+                 .per(per_page)
+                 .pluck(Arel.sql('id AS product_id'), Arel.sql('price_cents / 100.0 AS value'))
+                 .collect { |product_id, value| { product_id:, value: } }
+        end
+
+        render json: products
+      end
     end
-
-    if per_page.present? && per_page.to_i <= 0
-      return render json: { error: I18n.t('products.errors.invalid_per_page') }, status: :bad_request
-    end
-
-    products = ActiveRecord::Base.connected_to(role: :reading) do
-      Product.order(:id)
-             .page(page)
-             .per(per_page)
-             .pluck(Arel.sql('id AS product_id'), Arel.sql('price_cents / 100.0 AS value'))
-             .collect { |product_id, value| { product_id:, value: } }
-    end
-
-    render json: products
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,7 @@ en:
     errors:
       invalid_page: Invalid page
       invalid_per_page: Invalid per_page
+  orders:
+    errors:
+      invalid_page: Invalid page
+      invalid_per_page: Invalid per_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :imports, only: %i[index create]
+      resources :orders, only: %i[index]
       resources :products, only: %i[index]
     end
   end

--- a/db/migrate/20250831133839_add_index_to_order_items_order_id.rb
+++ b/db/migrate/20250831133839_add_index_to_order_items_order_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToOrderItemsOrderId < ActiveRecord::Migration[8.0]
+  def change
+    add_index :order_items, :order_id
+  end
+end

--- a/db/migrate/20250831134025_add_index_to_orders_on_id_and_date.rb
+++ b/db/migrate/20250831134025_add_index_to_orders_on_id_and_date.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToOrdersOnIdAndDate < ActiveRecord::Migration[8.0]
+  def change
+    add_index :orders, %i[id date]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_30_210908) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_31_134025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_30_210908) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["order_id", "product_id", "price_cents"], name: "index_order_items_on_order_id_and_product_id_and_price_cents", unique: true
+    t.index ["order_id"], name: "index_order_items_on_order_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -62,6 +63,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_30_210908) do
     t.date "date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["id", "date"], name: "index_orders_on_id_and_date"
   end
 
   create_table "products", force: :cascade do |t|

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :order_item, class: OrderItem do
+    product { create(:product) }
     price_cents { Faker::Number.number(digits: 5) }
   end
 end

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :order_item, class: OrderItem
+  factory :order_item, class: OrderItem do
+    price_cents { Faker::Number.number(digits: 5) }
+  end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :order, class: Order
+  factory :order, class: Order do
+    user { create(:user) }
+    date { Faker::Date.backward(days: 30) }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user, class: User
+  factory :user, class: User do
+    name { Faker::Name.name }
+  end
 end

--- a/spec/requests/api/v1/imports_spec.rb
+++ b/spec/requests/api/v1/imports_spec.rb
@@ -3,18 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Imports', type: :request do
-  describe 'GET /index', :f do
-    before { create_list(:import, 50) }
+  describe 'GET /index' do
+    let!(:imports) { create_list(:import, 50) }
 
     it 'returns a list of imports' do
       get '/api/v1/imports'
 
-      expected_imports = Import
-                         .order(:created_at)
-                         .page(1)
-                         .per(25)
-                         .pluck(Arel.sql('id AS import_id'), :status)
-                         .collect { |import_id, status| { 'import_id' => import_id, 'status' => status } }
+      expected_imports = imports
+                         .sort_by(&:created_at)
+                         .first(25)
+                         .collect { |i| { 'import_id' => i.id, 'status' => i.status } }
 
       expect(response.parsed_body).to match_array(expected_imports)
     end
@@ -25,12 +23,10 @@ RSpec.describe 'Api::V1::Imports', type: :request do
       it 'returns a list of imports for the specified page' do
         get '/api/v1/imports', params: { page: }
 
-        expected_imports = Import
-                           .order(:created_at)
-                           .page(page)
-                           .per(25)
-                           .pluck(Arel.sql('id AS import_id'), :status)
-                           .collect { |import_id, status| { 'import_id' => import_id, 'status' => status } }
+        expected_imports = imports
+                           .sort_by(&:created_at)
+                           .slice(25, 25)
+                           .collect { |i| { 'import_id' => i.id, 'status' => i.status } }
 
         expect(response.parsed_body).to match_array(expected_imports)
       end
@@ -42,12 +38,10 @@ RSpec.describe 'Api::V1::Imports', type: :request do
       it 'returns a list of imports with the specified per_page' do
         get '/api/v1/imports', params: { per_page: }
 
-        expected_imports = Import
-                           .order(:created_at)
-                           .page(1)
-                           .per(per_page)
-                           .pluck(Arel.sql('id AS import_id'), :status)
-                           .collect { |import_id, status| { 'import_id' => import_id, 'status' => status } }
+        expected_imports = imports
+                           .sort_by(&:created_at)
+                           .first(10)
+                           .collect { |i| { 'import_id' => i.id, 'status' => i.status } }
 
         expect(response.parsed_body).to match_array(expected_imports)
       end

--- a/spec/requests/api/v1/orders_spec.rb
+++ b/spec/requests/api/v1/orders_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Orders', type: :request do
+  describe 'GET /index' do
+    let!(:order_items) do
+      orders.flat_map { |order| create_list(:order_item, 2, order:) }
+    end
+
+    let(:orders) do
+      create_list(:order, 50)
+    end
+
+    it 'returns a list of orders' do
+      get '/api/v1/orders'
+
+      expected_orders = build_expected_orders(orders, order_items).first(25)
+
+      expect(response.parsed_body).to match_array(expected_orders)
+    end
+
+    context 'with page' do
+      let(:page) { 2 }
+
+      it 'returns a list of orders for the specified page' do
+        get '/api/v1/orders', params: { page: }
+
+        expected_orders = build_expected_orders(orders, order_items).slice(25, 25)
+
+        expect(response.parsed_body).to match_array(expected_orders)
+      end
+    end
+
+    context 'with per_page' do
+      let(:per_page) { 10 }
+
+      it 'returns a list of orders with the specified per_page' do
+        get '/api/v1/orders', params: { per_page: }
+
+        expected_orders = build_expected_orders(orders, order_items).first(per_page)
+
+        expect(response.parsed_body).to match_array(expected_orders)
+      end
+    end
+
+    context 'with invalid page' do
+      it 'returns a 400 status code' do
+        get '/api/v1/orders', params: { page: 'invalid' }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns an error message' do
+        get '/api/v1/orders', params: { page: 'invalid' }
+
+        expect(response.parsed_body['error']).to eq('Invalid page')
+      end
+    end
+
+    context 'with invalid per_page' do
+      it 'returns a 400 status code' do
+        get '/api/v1/orders', params: { per_page: 'invalid' }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns an error message' do
+        get '/api/v1/orders', params: { per_page: 'invalid' }
+
+        expect(response.parsed_body['error']).to eq('Invalid per_page')
+      end
+    end
+
+    private
+
+    def build_expected_orders(orders, order_items)
+      grouped_order_items = order_items.group_by(&:order_id)
+
+      orders.sort_by(&:id).each_with_object([]) do |order, memo|
+        result = build_expected_order(grouped_order_items, order)
+
+        memo << {
+          'order_id' => order.id,
+          'date' => order.date.to_s,
+          'total' => format('%0.2f', result[:total] / 100.0),
+          'products' => match_array(result[:products])
+        }
+      end
+    end
+
+    def build_expected_order(grouped_order_items, order)
+      grouped_order_items[order.id].each_with_object(products: [], total: 0) do |item, memo|
+        memo[:products] << { 'product_id' => item.product_id, 'value' => format('%0.2f', item.price_cents / 100.0) }
+        memo[:total] += item.price_cents
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -4,17 +4,15 @@ require 'rails_helper'
 
 RSpec.describe 'Api::V1::Products', type: :request do
   describe 'GET /index' do
-    before { create_list(:product, 50) }
+    let!(:products) { create_list(:product, 50) }
 
     it 'returns a list of products' do
       get '/api/v1/products'
 
-      expected_products = Product
-                          .order(:id)
-                          .page(1)
-                          .per(25)
-                          .pluck(Arel.sql('id AS product_id'), Arel.sql('price_cents / 100.0 AS value'))
-                          .collect { |product_id, value| { 'product_id' => product_id, 'value' => value.to_s } }
+      expected_products = products
+                          .sort_by(&:id)
+                          .first(25)
+                          .collect { |p| { 'product_id' => p.id, 'value' => (p.price_cents / 100.0).to_s } }
 
       expect(response.parsed_body).to match_array(expected_products)
     end
@@ -25,12 +23,10 @@ RSpec.describe 'Api::V1::Products', type: :request do
       it 'returns a list of products for the specified page' do
         get '/api/v1/products', params: { page: }
 
-        expected_products = Product
-                            .order(:id)
-                            .page(page)
-                            .per(25)
-                            .pluck(Arel.sql('id AS product_id'), Arel.sql('price_cents / 100.0 AS value'))
-                            .collect { |product_id, value| { 'product_id' => product_id, 'value' => value.to_s } }
+        expected_products = products
+                            .sort_by(&:id)
+                            .slice(25, 25)
+                            .collect { |p| { 'product_id' => p.id, 'value' => (p.price_cents / 100.0).to_s } }
 
         expect(response.parsed_body).to match_array(expected_products)
       end
@@ -42,12 +38,10 @@ RSpec.describe 'Api::V1::Products', type: :request do
       it 'returns a list of products with the specified per_page' do
         get '/api/v1/products', params: { per_page: }
 
-        expected_products = Product
-                            .order(:id)
-                            .page(1)
-                            .per(per_page)
-                            .pluck(Arel.sql('id AS product_id'), Arel.sql('price_cents / 100.0 AS value'))
-                            .collect { |product_id, value| { 'product_id' => product_id, 'value' => value.to_s } }
+        expected_products = products
+                            .sort_by(&:id)
+                            .first(10)
+                            .collect { |p| { 'product_id' => p.id, 'value' => (p.price_cents / 100.0).to_s } }
 
         expect(response.parsed_body).to match_array(expected_products)
       end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Api::V1::Products', type: :request do
 
         expected_products = products
                             .sort_by(&:id)
-                            .first(10)
+                            .first(per_page)
                             .collect { |p| { 'product_id' => p.id, 'value' => (p.price_cents / 100.0).to_s } }
 
         expect(response.parsed_body).to match_array(expected_products)

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -8,6 +8,8 @@ servers:
 tags:
   - name: imports
     description: Access to the imports
+  - name: orders
+    description: Access to the orders
   - name: products
     description: Access to the products
 
@@ -100,6 +102,54 @@ paths:
                 properties:
                   error:
                     type: string
+  /orders:
+    get:
+      tags:
+        - orders
+      summary: List orders
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    order_id:
+                      type: integer
+                    date:
+                      type: date
+                    total:
+                      type: string
+                    products:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          product_id:
+                            type: integer
+                          value:
+                            type: string
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
   /products:
     get:
       tags:
@@ -127,8 +177,7 @@ paths:
                     product_id:
                       type: integer
                     value:
-                      type: number
-                      format: double
+                      type: string
         '400':
           description: Bad Request
           content:


### PR DESCRIPTION
## Problem

It's required to have an endpoint for listing the orders.

## Solution

This PR adds the Orders Controller index action to list the orders. And creates two indexes to optimize the query.

**Before indexes**

```
 GroupAggregate  (cost=143.68..621.58 rows=1843 width=76)
   Group Key: orders.id
   ->  Merge Join  (cost=143.68..496.00 rows=6222 width=24)
         Merge Cond: (order_items.order_id = orders.id)
         ->  Index Only Scan using index_order_items_on_order_id_and_product_id_and_price_cents on order_items  (cost=0.28..265.61 rows=6222 width=20)
         ->  Sort  (cost=143.39..148.00 rows=1843 width=12)
               Sort Key: orders.id
               ->  Seq Scan on orders  (cost=0.00..43.43 rows=1843 width=12)
```

**After indexes**

```
 GroupAggregate  (cost=0.56..605.50 rows=1843 width=76)
   Group Key: orders.id
   ->  Merge Join  (cost=0.56..479.92 rows=6222 width=24)
         Merge Cond: (orders.id = order_items.order_id)
         ->  Index Only Scan using index_orders_on_id_and_date on orders  (cost=0.28..131.92 rows=1843 width=12)
         ->  Index Only Scan using index_order_items_on_order_id_and_product_id_and_price_cents on order_items  (cost=0.28..265.61 rows=6222 width=20)
```

## :stethoscope: Testing

**Setup**

```sh
docker compose build
```

```sh
docker compose up -d
```

Import the orders files following the steps of PR #5

**:test_tube: Scenario 1:** List the orders using the orders resource

<img width="1587" height="951" alt="image" src="https://github.com/user-attachments/assets/a4070510-89f3-4c4a-84b2-f8e290b83385" />
