### PR TITLE
feat: add imports show action

### DIFF
--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -47,6 +47,12 @@ module Api
 
         render json: { import_id: import.id }, status: :created
       end
+
+      def show
+        import = Import.find(params[:id])
+
+        render json: { import_id: import.id, status: import.status }
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api do
     namespace :v1 do
-      resources :imports, only: %i[index create]
+      resources :imports, only: %i[index create show]
       resources :orders, only: %i[index]
       resources :products, only: %i[index]
       resources :users, only: %i[index]

--- a/spec/requests/api/v1/imports_spec.rb
+++ b/spec/requests/api/v1/imports_spec.rb
@@ -157,4 +157,30 @@ RSpec.describe 'Api::V1::Imports', type: :request do
       end
     end
   end
+
+  describe 'GET /show' do
+    let(:import) { create(:import) }
+
+    it 'returns a 200 status code' do
+      get "/api/v1/imports/#{import.id}"
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the import' do
+      get "/api/v1/imports/#{import.id}"
+
+      expected_import = { 'import_id' => import.id, 'status' => import.status }
+
+      expect(response.parsed_body).to match(expected_import)
+    end
+
+    context 'when the import does not exist' do
+      it 'returns a 404 status code' do
+        get '/api/v1/imports/x'
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -104,6 +104,37 @@ paths:
                 properties:
                   error:
                     type: string
+  /imports/{id}:
+    get:
+      tags:
+        - imports
+      summary: Get import by id
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  import_id:
+                    type: integer
+                  status:
+                    type: string
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
   /orders:
     get:
       tags:


### PR DESCRIPTION
## Problem

It's required to have an endpoint for get a specified import.

## Solution

This PR adds the Imports Controller show action to get a import by id.

## :stethoscope: Testing

**Setup**

```sh
docker compose build
```

```sh
docker compose up -d
```

Import the orders files following the steps of PR #5

**:test_tube: Scenario 1:** Get a import using the imports resource

<img width="1521" height="961" alt="image" src="https://github.com/user-attachments/assets/b0d8d814-d47a-4745-989b-d54ab309e5f4" />
