### PR TITLE
feat: add data range filter to orders controller

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -6,6 +6,8 @@ module Api
       def index
         page = params[:page]
         per_page = params[:per_page]
+        start_date = parse_date(params[:start_date], Time.at(0).to_date)
+        end_date = parse_date(params[:end_date], Time.zone.today)
 
         if page.present? && page.to_i <= 0
           return render json: { error: I18n.t('orders.errors.invalid_page') }, status: :bad_request
@@ -15,36 +17,56 @@ module Api
           return render json: { error: I18n.t('orders.errors.invalid_per_page') }, status: :bad_request
         end
 
-        orders = ActiveRecord::Base.connected_to(role: :reading) do
-          Order
-            .select(
-              'orders.id AS order_id',
-              'orders.date AS date',
-              <<~SQL.squish
-                COALESCE(
-                  to_char(SUM(order_items.price_cents) / 100.0, 'FM999999999.00'),
-                  '0.00'
-                ) AS total,
-                COALESCE(
-                  json_agg(
-                    json_build_object(
-                      'product_id', order_items.product_id,
-                      'value', to_char(order_items.price_cents / 100.0, 'FM999999999.00')
-                    )
-                  ) FILTER (WHERE order_items.product_id IS NOT NULL),
-                  '[]'
-                ) AS products
-              SQL
-            )
-            .joins(:order_items)
-            .group('orders.id', 'orders.date')
-            .order(:id)
-            .page(page)
-            .per(per_page)
-            .as_json(except: %i[id])
+        if start_date > end_date
+          return render json: { error: I18n.t('orders.errors.invalid_date_range') }, status: :bad_request
         end
 
+        orders = fetch_orders(page, per_page, start_date, end_date)
+
         render json: orders
+      end
+
+      private
+
+      def parse_date(date_str, default)
+        Date.parse(date_str)
+      rescue StandardError
+        default
+      end
+
+      def fetch_orders(page, per_page, start_date, end_date)
+        ActiveRecord::Base.connected_to(role: :reading) do
+          query = Order
+                  .select(
+                    'orders.id AS order_id',
+                    'orders.date AS date',
+                    <<~SQL.squish
+                      COALESCE(
+                        to_char(SUM(order_items.price_cents) / 100.0, 'FM999999999.00'),
+                        '0.00'
+                      ) AS total,
+                      COALESCE(
+                        json_agg(
+                          json_build_object(
+                            'product_id', order_items.product_id,
+                            'value', to_char(order_items.price_cents / 100.0, 'FM999999999.00')
+                          )
+                        ) FILTER (WHERE order_items.product_id IS NOT NULL),
+                        '[]'
+                      ) AS products
+                    SQL
+                  )
+                  .joins(:order_items)
+                  .group('orders.id', 'orders.date')
+                  .order(:id)
+                  .page(page).per(per_page)
+
+          query = query.where('orders.date >= ?', start_date) if start_date.present?
+
+          query = query.where('orders.date <= ?', end_date) if end_date.present?
+
+          query.as_json(except: %i[id])
+        end
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
     errors:
       invalid_page: Invalid page
       invalid_per_page: Invalid per_page
+      invalid_date_range: Invalid date range
   products:
     errors:
       invalid_page: Invalid page

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -149,6 +149,16 @@ paths:
           name: per_page
           schema:
             type: integer
+        - in: query
+          name: start_date
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: end_date
+          schema:
+            type: string
+            format: date
       responses:
         '200':
           description: OK


### PR DESCRIPTION
## Problem

It's required to support date range to filter the orders

## Solution

This PR updates the Orders Controller to support date range filters

## :stethoscope: Testing

**Setup**

```sh
docker compose build
```

```sh
docker compose up -d
```

Import the orders files following the steps of PR #5

**:test_tube: Scenario 1:** List the orders using the orders resource filtering by date range

<img width="1526" height="959" alt="image" src="https://github.com/user-attachments/assets/8ebf413c-e258-4346-8e99-0cf2ad821998" />
