### PR TITLE
feat: add order id filter to users controller

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -6,6 +6,7 @@ module Api
       def index
         page = params[:page]
         per_page = params[:per_page]
+        order_id = params[:order_id]
         order_start_date = parse_date(params[:order_start_date], Time.at(0).to_date)
         order_end_date = parse_date(params[:order_end_date], Time.zone.today)
 
@@ -21,7 +22,7 @@ module Api
           return render json: { error: I18n.t('users.errors.invalid_date_range') }, status: :bad_request
         end
 
-        users = fetch_users(page, per_page, order_start_date, order_end_date)
+        users = fetch_users(page, per_page, order_id, order_start_date, order_end_date)
 
         render json: users
       end
@@ -34,7 +35,7 @@ module Api
         default
       end
 
-      def fetch_users(page, per_page, order_start_date, order_end_date)
+      def fetch_users(page, per_page, order_id, order_start_date, order_end_date)
         ActiveRecord::Base.connected_to(role: :reading) do
           query = User
                   .select(
@@ -88,6 +89,7 @@ module Api
                   .page(page)
                   .per(per_page)
 
+          query = query.where('orders.id = ?', order_id.to_i) if order_id.present?
           query = query.where('orders.date >= ?', order_start_date) if order_start_date.present?
           query = query.where('orders.date <= ?', order_end_date) if order_end_date.present?
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe 'Api::V1::Users', type: :request do
       end
     end
 
+    context 'with order_id' do
+      let(:order) { users[0].orders[0] }
+
+      it 'returns a list of users with the specified order_id' do
+        get '/api/v1/users', params: { order_id: order.id }
+
+        expected_users = build_expected_users([users[0]], [order])
+
+        expect(response.parsed_body).to match_array(expected_users)
+      end
+    end
+
     context 'when order_start_date is after order_end_date' do
       let(:order_start_date) { 10.days.from_now.to_date }
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -245,6 +245,10 @@ paths:
           schema:
             type: integer
         - in: query
+          name: order_id
+          schema:
+            type: integer
+        - in: query
           name: order_start_date
           schema:
             type: string


### PR DESCRIPTION
## Problem

It's required to support order id to filter the users

## Solution

This PR updates the Users Controller to support the order id filter

## :stethoscope: Testing

**Setup**

```sh
docker compose build
```

```sh
docker compose up -d
```

Import the orders files following the steps of PR #5

**:test_tube: Scenario 1:** List the users using the users resource filtering by order id

<img width="1030" height="955" alt="image" src="https://github.com/user-attachments/assets/cdcc2a1c-fe0e-4199-a5a4-fd6665f07bc5" />
